### PR TITLE
chore!: replace githubv4 with github.com/google/go-github

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,8 @@ go 1.14
 
 require (
 	github.com/aevea/magefiles v0.0.0-20200424121010-0004d5a7a2fe
+	github.com/google/go-github/v32 v32.1.0
 	github.com/magefile/mage v1.10.0
-	github.com/shurcooL/githubv4 v0.0.0-20200627185320-e003124d66e4
-	github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.4.0
 	golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be

--- a/go.sum
+++ b/go.sum
@@ -58,10 +58,16 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
+github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -120,10 +126,6 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
-github.com/shurcooL/githubv4 v0.0.0-20200627185320-e003124d66e4 h1:cjmR6xY0f89IwBYMSwUrkFs4/1+KKw30Df3SqT7nZ6Q=
-github.com/shurcooL/githubv4 v0.0.0-20200627185320-e003124d66e4/go.mod h1:hAF0iLZy4td2EX+/8Tw+4nodhlMrwN3HupfaXj3zkGo=
-github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f h1:tygelZueB1EtXkPI6mQ4o9DQ0+FKW41hTbunoXZCTqk=
-github.com/shurcooL/graphql v0.0.0-20181231061246-d48a9a75455f/go.mod h1:AuYgA5Kyo4c7HfUmvRGs/6rGlMMV/6B1bVnB9JxJEEg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=

--- a/internal/github_client/client.go
+++ b/internal/github_client/client.go
@@ -3,13 +3,13 @@ package githubclient
 import (
 	"context"
 
-	"github.com/shurcooL/githubv4"
+	"github.com/google/go-github/v32/github"
 	"golang.org/x/oauth2"
 )
 
 // Client contains the set up github client and allowed queries to communicate with Github.
 type Client struct {
-	ghClient *githubv4.Client
+	ghClient *github.Client
 }
 
 // New bootstraps the Client struct
@@ -19,7 +19,7 @@ func New(token string) *Client {
 	)
 	httpClient := oauth2.NewClient(context.Background(), src)
 
-	client := githubv4.NewClient(httpClient)
+	client := github.NewClient(httpClient)
 
 	return &Client{
 		ghClient: client,

--- a/internal/github_client/latest_commit_on_branch.go
+++ b/internal/github_client/latest_commit_on_branch.go
@@ -2,8 +2,7 @@ package githubclient
 
 import (
 	"context"
-
-	"github.com/shurcooL/githubv4"
+	"fmt"
 )
 
 var latestCommitQuery struct {
@@ -17,17 +16,13 @@ var latestCommitQuery struct {
 }
 
 func (client *Client) LatestCommitOnBranch(owner, repo, reference, commit string) (bool, error) {
-	variables := map[string]interface{}{
-		"owner":     githubv4.String(owner),
-		"repo":      githubv4.String(repo),
-		"reference": githubv4.String(reference),
-	}
+	ctx := context.Background()
 
-	err := client.ghClient.Query(context.Background(), &latestCommitQuery, variables)
+	ref, _, err := client.ghClient.Git.GetRef(ctx, owner, repo, fmt.Sprintf("heads/%s", reference))
 
 	if err != nil {
 		return false, err
 	}
 
-	return latestCommitQuery.Repository.Ref.Target.OID == commit, nil
+	return *ref.Object.SHA == commit, nil
 }


### PR DESCRIPTION
BREAKING CHANGE: The GraphQL API of Github doesn't support all the features that the old API had. Therefore we need to switch to the old ones.

Particularly the Status check API is needed.