### PR TITLE
chore: use status API instead of check API

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ is-latest-commit is used to compare a given commit against a given branch to ver
 | reference    | CI_COMMIT_REF_NAME | true     | Branch name to check against                                                     | v0.1.0       |
 | commit       | CI_COMMIT_SHA      | true     | Full commit SHA which will be used to compare against the latest on given branch | v0.1.0       |
 
+### set-status-check
+
+set-status-check allows a user arbitrarily set a status check for a given commit. This allows us to mirror the job status to Github from Gitlab as by default the Gitlab <> Github integration only displays `ci/gitlab/gitlab.com` in the status section in Github. This leads to improved DX.
+
+> Usage: `gitlab-tools set-status-check --status pending`
+
+| Flag | Env Variable | Required | Description | From version |
+| ---- | ------------ | -------- | ------------ | ----------- |
+| github-token | GITHUB_TOKEN | true | Github token with API permissions | v0.2.0 |
+| repository | GITHUB_REPOSITORY | true | Github repository name in format owner/repo | v0.2.0 |
+| status | STATUS | true | Status to be set, allowed are: **error**, **failure**, **pending** or **success** | v0.2.0 |
+| exit-code | none | false | Sets status based on a given error code **overrides status flag** | v0.2.0 |
+| commit | CI_COMMIT_SHA | true | Commit sha for which to set the status | v0.2.0 |
+| status-name | CI_JOB_STAGE/CI_JOB_NAME | true | Name of status that will be shown in Github | v0.2.0 |
+| description | STATUS_DESCRIPTION | false | Extra information to show in Github. e.g. number of failed checks | v0.2.0 |
+| url | CI_JOB_URL | false | Link to the given job in Gitlab | v0.2.0 |
+
 ## CI
 
 To use in Gitlab you can use the following template:

--- a/internal/github_client/set_check_status.go
+++ b/internal/github_client/set_check_status.go
@@ -6,16 +6,17 @@ import (
 	"github.com/google/go-github/v32/github"
 )
 
-func (client *Client) SetCheckStatus(owner, repo, status, jobName, commit string) error {
+func (client *Client) SetCheckStatus(owner, repo, status, jobName, description, jobURL, commit string) error {
 	ctx := context.Background()
 
-	options := github.CreateCheckRunOptions{
-		Name:    jobName,
-		HeadSHA: commit,
-		Status:  &status,
+	options := github.RepoStatus{
+		State:       &status,
+		Description: &description,
+		Context:     &jobName,
+		TargetURL:   &jobURL,
 	}
 
-	_, _, err := client.ghClient.Checks.CreateCheckRun(ctx, owner, repo, options)
+	_, _, err := client.ghClient.Repositories.CreateStatus(ctx, owner, repo, commit, &options)
 
 	return err
 }


### PR DESCRIPTION
Checks API is only permitted for Github apps. Status API allows us to set status per commit using just a base token. This will allow us to show the user which jobs in Gitlab failed or succeeded.